### PR TITLE
fix: Rename chunk even if chunk cache does not exist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,16 +25,19 @@ jobs:
       run: bundle exec parallel_test -n 2 --group-by filesize --only-group ${{ matrix.group }} --verbose
       env:
         RECORD_RUNTIME: "true"
-    - name: "Runtime cache: clear chunk"
+    - name: "Runtime cache: clear previous chunk cache"
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         gh extension install actions/gh-actions-cache
         gh actions-cache delete runtime-cache-${{ matrix.group }} --confirm
+      continue-on-error: true # do not fail in case the key was deleted by a parallel run
+    - name: "Runtime cache: prepare chunk"
+      shell: bash
+      run: |
         mkdir -p tmp/parallel_runtime_test
         mv tmp/parallel_runtime_test.log tmp/parallel_runtime_test/${{ matrix.group }}.log
-      continue-on-error: true # do not fail in case the key was deleted by a parallel run
     - name: "Runtime cache: store chunk"
       uses: actions/cache/save@v4
       with:


### PR DESCRIPTION
Hi, thank you for this example repo.

In the example workflow I noticed that renaming the chunk for caching would not happen if clearing the chunk cache fails, e.g. if the chunk was not cached before.

This splits it into two steps so that the chunks get renamed for caching, even if clearing previous caches fails for any reason.