### PR TITLE
Fix: Group by runtime when it exists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         key: runtime-cache-all
         path: tmp/parallel_runtime_test.log
     - name: rake test # change to `--group-by filesize` when this runtime is missing or bad
-      run: bundle exec parallel_test -n 2 --group-by filesize --only-group ${{ matrix.group }} --verbose
+      run: bundle exec parallel_test -n 2 --group-by runtime --only-group ${{ matrix.group }} --verbose
       env:
         RECORD_RUNTIME: "true"
     - name: "Runtime cache: clear previous chunk cache"


### PR DESCRIPTION
Hi. Thanks for the fantastic gem and this repo, it has been incredibly helpful for my project!

While using this example for my project I noticed that it should group by `runtime` when the runtime log exists.
There's already a comment above explaining how to handle cases where the runtime is missing or bad.
